### PR TITLE
Add support for Node.js 20 and upgrade buster to bookworm

### DIFF
--- a/.github/workflows/build-toolchains.yml
+++ b/.github/workflows/build-toolchains.yml
@@ -15,10 +15,11 @@ jobs:
     strategy:
       matrix:
         language: [
-          'node:8',
+          #'node:8',
           'node:10',
           'node:12',
           'node:14',
+          'node:20',
           #'python:3.5.10',
           'python:3.6.12',
           'python:3.7.9',

--- a/build-toolchains-manual.sh
+++ b/build-toolchains-manual.sh
@@ -11,8 +11,8 @@
 languages=(
   #node:linux-arm:8
   #node:linux-arm:10
-  node:linux-arm:12
-  node:linux-arm:14
+  #node:linux-arm:12
+  #node:linux-arm:14
   #node:linux-arm64:8
   #node:linux-arm64:10
   #node:linux-arm64:12
@@ -21,6 +21,7 @@ languages=(
   #node:linux-x64:10
   #node:linux-x64:12
   #node:linux-x64:14
+  node:linux-x64:20
   #python:linux-arm:3.5.10
   #python:linux-arm:3.6.12
   #python:linux-arm:3.7.9

--- a/toolchain/linux-arm/node/Dockerfile
+++ b/toolchain/linux-arm/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM balenalib/raspberry-pi-debian:buster
+FROM balenalib/raspberry-pi-debian:bookworm
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG NODE_VERSION
@@ -20,7 +20,7 @@ RUN apt update && \
         liblzma-dev \
         libudev-dev \
         pkg-config \
-        python \
+        python3 \
         sudo \
         zlib1g-dev && \
     apt clean && \
@@ -28,6 +28,5 @@ RUN apt update && \
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
     bash -c "export NVM_DIR=\${HOME}/.nvm && \
         source \${NVM_DIR}/nvm.sh && \
-        npm config -g set unsafe-perm true && \
         npm config -g set cache /tmp/.npm && \
         nvm cache clear"

--- a/toolchain/linux-arm64/node/Dockerfile
+++ b/toolchain/linux-arm64/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:buster
+FROM arm64v8/debian:bookworm
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG NODE_VERSION
@@ -20,7 +20,7 @@ RUN apt update && \
         liblzma-dev \
         libudev-dev \
         pkg-config \
-        python \
+        python3 \
         sudo \
         zlib1g-dev && \
     apt clean && \
@@ -28,6 +28,5 @@ RUN apt update && \
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
     bash -c "export NVM_DIR=\${HOME}/.nvm && \
         source \${NVM_DIR}/nvm.sh && \
-        npm config -g set unsafe-perm true && \
         npm config -g set cache /tmp/.npm && \
         nvm cache clear"

--- a/toolchain/linux-x64/node/Dockerfile
+++ b/toolchain/linux-x64/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG NODE_VERSION
@@ -20,7 +20,7 @@ RUN apt update && \
         liblzma-dev \
         libudev-dev \
         pkg-config \
-        python \
+        python3 \
         sudo \
         zlib1g-dev && \
     apt clean && \
@@ -28,6 +28,5 @@ RUN apt update && \
     curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash && \
     bash -c "export NVM_DIR=\${HOME}/.nvm && \
         source \${NVM_DIR}/nvm.sh && \
-        npm config -g set unsafe-perm true && \
         npm config -g set cache /tmp/.npm && \
         nvm cache clear"


### PR DESCRIPTION
Closes #60.

This PR:
- Adds support for Node.js 20
- Removes Node.js 8 from the build matrix
- Upgrades Node.js base images from buster to bookworm (necessary to support Node.js 20)
- Replaces the python package with the python3 package in Node.js toolchains (because there's no python package in bookworm)
- Removes the unsafe-perm config for npm (since it doesn't exist from npm 7)

As discussed in previous PRs there's a chance the upgrade from buster to bookworm may break some native dependencies for new releases of some add-ons, but I think we just have to accept that at this points since buster is EOL.

I'm also not sure what the unsafe-perm config was needed for, but I'm not sure if there's anything to replace it? I understand the way npm deals with permissions changed in npm 7 onwards.